### PR TITLE
Add 'create shows' feature

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -31,6 +31,12 @@ export default function TabLayout() {
           title: 'Payment',
         }}
       />
+      <Tabs.Screen
+        name="newshow"
+        options={{
+          title: 'Shows',
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/newshow.tsx
+++ b/app/(tabs)/newshow.tsx
@@ -1,0 +1,5 @@
+import ShowFormScreen from '@/src/components/screens/ShowFormScreen';
+
+export default function NewShow() {
+  return <ShowFormScreen />;
+}

--- a/src/components/screens/ShowFormScreen.tsx
+++ b/src/components/screens/ShowFormScreen.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect } from 'react';
+import {
+  TextInput,
+  Text,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  View,
+  Alert,
+} from 'react-native';
+
+import CustomButton from '../buttons/CustomButton';
+import { useAuth } from '../../contexts/AuthContext';
+import { fireStoreDB } from '../../configs/firebaseConfig';
+import { createNewShowService } from '../../services/showService';
+import { getBandIDs } from '../../services/bandService';
+
+const ShowFormScreen = () => {
+  const { authState } = useAuth();
+  const [showName, setShowName] = useState('');
+  const [showDate, setShowDate] = useState('');
+  const [showLocation, setShowLocation] = useState('');
+  const [selectedBandId, setSelectedBandId] = useState('');
+  const [userBands, setUserBands] = useState<Record<string, string>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingBands, setIsLoadingBands] = useState(true);
+
+  // Load user's bands on component mount
+  useEffect(() => {
+    const loadUserBands = async () => {
+      if (!authState.user) {
+        setIsLoadingBands(false);
+        return;
+      }
+
+      try {
+        const bands = await getBandIDs(fireStoreDB, authState.user);
+        setUserBands(bands);
+        
+        // Auto-select first band if only one exists
+        const bandIds = Object.values(bands);
+        if (bandIds.length === 1) {
+          setSelectedBandId(bandIds[0]);
+        }
+      } catch (error: any) {
+        console.error('Error loading bands:', error);
+        Alert.alert('Error', 'Failed to load your bands');
+      } finally {
+        setIsLoadingBands(false);
+      }
+    };
+
+    loadUserBands();
+  }, [authState.user]);
+
+  const handleCreateShow = async () => {
+    if (!authState.user) {
+      Alert.alert('Error', 'You must be logged in to create a show');
+      return;
+    }
+
+    if (!showName || !showDate || !showLocation || !selectedBandId) {
+      Alert.alert('Error', 'Please fill in all fields and select a band');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const showId = await createNewShowService(
+        fireStoreDB,
+        authState.user,
+        showName,
+        showDate,
+        showLocation,
+        selectedBandId
+      );
+      
+      Alert.alert('Success', 'Show created successfully!', [
+        {
+          text: 'OK',
+          onPress: () => {
+            // Reset form
+            setShowName('');
+            setShowDate('');
+            setShowLocation('');
+          },
+        },
+      ]);
+    } catch (error: any) {
+      Alert.alert('Error', error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading || isLoadingBands) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <ActivityIndicator size="large" />
+        <Text className="mt-4">
+          {isLoading ? 'Creating show...' : 'Loading bands...'}
+        </Text>
+      </View>
+    );
+  }
+
+  // Check if user has any bands
+  const bandEntries = Object.entries(userBands);
+  const hasBands = bandEntries.length > 0;
+
+  return (
+    <ScrollView>
+      <KeyboardAvoidingView
+        id="main-content"
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex px-6 py-10 gap-6"
+      >
+        <Text className="font-semibold text-3xl">Create New Show 🎵</Text>
+        
+        {!hasBands && (
+          <View className="bg-yellow-100 p-4 rounded-md self-stretch">
+            <Text className="text-yellow-800 text-center">
+              You need to create or join a band before you can schedule shows.
+            </Text>
+          </View>
+        )}
+        
+        <View
+          id="form"
+          className="flex flex-col justify-center items-end gap-4 self-stretch"
+        >
+          {hasBands && (
+            <View className="flex flex-col items-start gap-2 self-stretch">
+              <Text>Select Band</Text>
+              <View className="bg-gray-200 border border-gray-300 rounded-md self-stretch">
+                {bandEntries.map(([bandName, bandId]) => (
+                  <CustomButton
+                    key={bandId}
+                    text={`${selectedBandId === bandId ? '✓ ' : ''}${bandName}`}
+                    onPress={() => setSelectedBandId(bandId)}
+                    variant={selectedBandId === bandId ? 'default' : 'default'}
+                  />
+                ))}
+              </View>
+            </View>
+          )}
+          <View className="flex flex-col items-start gap-2 self-stretch">
+            <Text>Show Name</Text>
+            <TextInput
+              className="bg-gray-200 p-4 border border-gray-300 rounded-md self-stretch"
+              placeholder="Concert at the venue"
+              placeholderTextColor="#8897AD"
+              onChangeText={(text) => setShowName(text)}
+              value={showName}
+              maxLength={50}
+            />
+          </View>
+          
+          <View className="flex flex-col items-start gap-2 self-stretch">
+            <Text>Date & Time</Text>
+            <TextInput
+              className="bg-gray-200 p-4 border border-gray-300 rounded-md self-stretch"
+              placeholder="YYYY-MM-DD HH:MM (e.g., 2025-12-31 20:00)"
+              placeholderTextColor="#8897AD"
+              onChangeText={(text) => setShowDate(text)}
+              value={showDate}
+            />
+          </View>
+          
+          <View className="flex flex-col items-start gap-2 self-stretch">
+            <Text>Location</Text>
+            <TextInput
+              className="bg-gray-200 p-4 border border-gray-300 rounded-md self-stretch"
+              placeholder="Venue name, address"
+              placeholderTextColor="#8897AD"
+              onChangeText={(text) => setShowLocation(text)}
+              value={showLocation}
+              maxLength={100}
+              multiline
+              numberOfLines={2}
+            />
+          </View>
+          
+          {hasBands ? (
+            <CustomButton
+              text="Create Show"
+              onPress={handleCreateShow}
+            />
+          ) : (
+            <Text className="text-gray-500 text-center">
+              Create or join a band to schedule shows
+            </Text>
+          )}
+        </View>
+      </KeyboardAvoidingView>
+    </ScrollView>
+  );
+};
+
+export default ShowFormScreen;

--- a/src/services/bandService.ts
+++ b/src/services/bandService.ts
@@ -49,11 +49,13 @@ export async function createNewBandService(
     name: bandName,
     owner: user.email,
     members: [],
+    shows: [],
   };
   const bandDoc = await addDoc(collection(fireStoreDB, 'bands'), {
     name: bandPayload.name,
     owner: bandPayload.owner,
     members: bandPayload.members,
+    shows: bandPayload.shows,
   });
 
   await updateDoc(docRef, {
@@ -138,6 +140,7 @@ export async function getBandInfo(
       name: docSnap.get('name'),
       owner: docSnap.get('owner'),
       members: docSnap.get('members'),
+      shows: docSnap.get('shows'),
     } as FirestoreBandType;
   });
 }

--- a/src/services/showService.test.ts
+++ b/src/services/showService.test.ts
@@ -1,0 +1,80 @@
+import { createNewShowService } from './showService';
+
+// Mock Firestore functions
+jest.mock('firebase/firestore', () => ({
+  addDoc: jest.fn(),
+  collection: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+  arrayUnion: jest.fn(),
+}));
+
+const mockFireStoreDB = {};
+const mockUser = {
+  uid: 'test-uid',
+  email: 'test@example.com',
+};
+
+describe('createNewShowService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw error if user is invalid', async () => {
+    await expect(
+      createNewShowService(mockFireStoreDB, null as any, 'Test Show', '2025-12-31 20:00', 'Test Location', 'test-bandid')
+    ).rejects.toThrow('User is invalid');
+  });
+
+  it('should throw error if show name is missing', async () => {
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, '', '2025-12-31 20:00', 'Test Location', 'test-bandid')
+    ).rejects.toThrow('Show name is required');
+  });
+
+  it('should throw error if show date is missing', async () => {
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, 'Test Show', '', 'Test Location', 'test-bandid')
+    ).rejects.toThrow('Show date is required');
+  });
+
+  it('should throw error if show location is missing', async () => {
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, 'Test Show', '2025-12-31 20:00', '', 'test-bandid')
+    ).rejects.toThrow('Show location is required');
+  });
+
+  it('should throw error if show name is too long', async () => {
+    const longName = 'a'.repeat(51);
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, longName, '2025-12-31 20:00', 'Test Location', 'test-bandid')
+    ).rejects.toThrow('Show name must be 50 characters or less');
+  });
+
+  it('should throw error if show location is too long', async () => {
+    const longLocation = 'a'.repeat(101);
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, 'Test Show', '2025-12-31 20:00', longLocation, 'test-bandid')
+    ).rejects.toThrow('Show location must be 100 characters or less');
+  });
+
+  it('should throw error if band ID is missing', async () => {
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, 'Test Show', '2025-12-31 20:00','Test Location', '')
+    ).rejects.toThrow('Band selection is required');
+  });
+
+  it('should throw error if date format is invalid', async () => {
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, 'Test Show', 'invalid-date', 'Test Location', 'test-bandid')
+    ).rejects.toThrow('Invalid date format');
+  });
+
+  it('should throw error if date is in the past', async () => {
+    const pastDate = '2020-01-01 12:00';
+    await expect(
+      createNewShowService(mockFireStoreDB, mockUser as any, 'Test Show', pastDate, 'Test Location', 'test-bandid')
+    ).rejects.toThrow('Show date must be in the future');
+  });
+});

--- a/src/services/showService.ts
+++ b/src/services/showService.ts
@@ -1,0 +1,150 @@
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  updateDoc,
+  arrayUnion,
+} from 'firebase/firestore';
+import { User } from 'firebase/auth';
+
+import { FirestoreShowType } from '../types/FirestoreShowType';
+
+export async function createNewShowService(
+  fireStoreDB: any,
+  user: User,
+  showName: string,
+  showDate: string,
+  showLocation: string,
+  bandId: string
+): Promise<string> {
+  if (!user || !user.email) {
+    throw new Error('User is invalid');
+  }
+  if (!showName) {
+    throw new Error('Show name is required');
+  }
+  if (!showDate) {
+    throw new Error('Show date is required');
+  }
+  if (!showLocation) {
+    throw new Error('Show location is required');
+  }
+  if (!bandId) {
+    throw new Error('Band selection is required');
+  }
+  if (showName.length > 50) {
+    throw new Error('Show name must be 50 characters or less');
+  }
+  if (showLocation.length > 100) {
+    throw new Error('Show location must be 100 characters or less');
+  }
+
+  // Validate date format (basic check)
+  const dateObj = new Date(showDate);
+  if (isNaN(dateObj.getTime())) {
+    throw new Error('Invalid date format');
+  }
+
+  // Check if date is in the future
+  if (dateObj < new Date()) {
+    throw new Error('Show date must be in the future');
+  }
+
+  // Verify band exists and user has access to it
+  const bandDocRef = doc(fireStoreDB, 'bands', bandId);
+  const bandDocSnap = await getDoc(bandDocRef);
+  
+  if (!bandDocSnap.exists()) {
+    throw new Error('Band not found');
+  }
+
+  // Check if user is owner or member of the band
+  const bandData = bandDocSnap.data();
+  const isOwner = bandData.owner === user.email;
+  const isMember = bandData.members.includes(user.email);
+  
+  if (!isOwner && !isMember) {
+    throw new Error('You do not have permission to create shows for this band');
+  }
+
+  // Create new show document
+  const showPayload: FirestoreShowType = {
+    name: showName,
+    date: showDate,
+    location: showLocation,
+    bandId: bandId,
+  };
+
+  const showDoc = await addDoc(collection(fireStoreDB, 'shows'), {
+    name: showPayload.name,
+    date: showPayload.date,
+    location: showPayload.location,
+    bandId: showPayload.bandId,
+    owner: user.email,
+    createdAt: new Date().toISOString(),
+  });
+  
+  // Add show ID to band's shows array
+  try {
+    await updateDoc(bandDocRef, {
+      shows: arrayUnion(showDoc.id),
+    });
+  } catch (error) {
+    console.log(error);
+    throw new Error('Failed to update band with show information');
+  }
+
+  return showDoc.id;
+}
+
+export async function getBandShowsService(
+  fireStoreDB: any,
+  bandId: string
+): Promise<FirestoreShowType[]> {
+  if (!bandId) {
+    throw new Error('Band ID is required');
+  }
+
+  // Get band document to get show IDs
+  const bandDocRef = doc(fireStoreDB, 'bands', bandId);
+  const bandDocSnap = await getDoc(bandDocRef);
+  
+  if (!bandDocSnap.exists()) {
+    throw new Error('Band not found');
+  }
+
+  const bandData = bandDocSnap.data();
+//   const showIds = bandData.shows || [];
+  const showIds = bandData.shows;
+
+  if (showIds.length === 0) {
+    return [];
+  }
+
+  // Fetch each show document
+  const shows: FirestoreShowType[] = [];
+  for (const showId of showIds) {
+    try {
+      const showDocRef = doc(fireStoreDB, 'shows', showId);
+      const showDocSnap = await getDoc(showDocRef);
+      
+      if (showDocSnap.exists()) {
+        const showData = showDocSnap.data();
+        shows.push({
+          name: showData.name,
+          date: showData.date,
+          location: showData.location,
+          bandId: showData.bandId,
+        });
+      }
+    } catch (error) {
+      console.log(`Error fetching show ${showId}:`, error);
+    }
+  }
+
+  // Sort shows by date (most recent first)
+  shows.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  return shows;
+}

--- a/src/types/FirestoreBandType.tsx
+++ b/src/types/FirestoreBandType.tsx
@@ -2,4 +2,5 @@ export interface FirestoreBandType {
   name: string;
   owner: string;
   members: string[];
+  shows: string[];
 }

--- a/src/types/FirestoreShowType.tsx
+++ b/src/types/FirestoreShowType.tsx
@@ -1,0 +1,6 @@
+export interface FirestoreShowType {
+  date: string;
+  name: string;
+  location: string;
+  bandId: string;
+}


### PR DESCRIPTION
Users can now create a show, which is then created in Firestore and attached to a band object by its show-id